### PR TITLE
Remove public CloudLinux repos from migration

### DIFF
--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el8
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el8
@@ -53,7 +53,9 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
 [cloudlinux8-baseos]
 name=CloudLinux 8 - BaseOS
 baseurl=https://repo.cloudlinux.com/cloudlinux/8/BaseOS/$basearch/os/
-enabled=1
+# keep cloudlinux8-baseos here because we need repository to install rhn-client-tools
+# but at the same time we don't want to use it during migration because we have CLN channel
+enabled=0
 gpgcheck=1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
 

--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el8
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el8
@@ -57,35 +57,9 @@ enabled=1
 gpgcheck=1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
 
-[cloudlinux8-appstream]
-name=CloudLinux 8 - AppStream
-baseurl=https://repo.cloudlinux.com/cloudlinux/8/AppStream/$basearch/os/
-enabled=1
-gpgcheck=1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
-
-[cloudlinux8-powertools]
-name=CloudLinux 8 - PowerTools
-baseurl=https://repo.cloudlinux.com/cloudlinux/8/PowerTools/$basearch/os/
-enabled=1
-gpgcheck=1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
-
 [cloudlinux8-elevate]
 name=CloudLinux 8 ELevate
 baseurl=https://repo.cloudlinux.com/elevate/8/$basearch/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
-
-# cloudlinux-PowerTools repo was added in 8.5 for compatibility reasons.
-# Third-party install scripts may pass --enablerepo=cloudlinux-PowerTools
-# to dnf and without this repo a error will occur
-
-[cloudlinux8-PowerTools]
-name=AlmaLinux 8 - PowerTools
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/powertools
-# baseurl=https://repo.almalinux.org/almalinux/8/PowerTools/$basearch/os/
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -5,7 +5,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.3
-Release:	2%{?dist}.%{pes_events_build_date}
+Release:	3%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -46,6 +46,9 @@ make install PREFIX=%{buildroot}
 
 
 %changelog
+* Thu Sep 26 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.3-3.cloudlinux
+ - Move GeoIP package if epel vendor is enabled
+
 * Wed Aug 21 2024 Oleksandr Shyshatskyi <oshyshatskyi@cloudlinux.com> - 0.3-0.cloudlinux
 - Rebase onto AlmaLinux
 


### PR DESCRIPTION
This change removes cloudlinux8-PowerTools, cloudlinux8-appstream and cloudlinux8-powertools from migration. cloudlinux8-baseos is not removed because it is needed to install rhn-client-tools and connect to CLN in order to receive updates from channel.