### PR TITLE
Fix configuration error in kernelcare repositories

### DIFF
--- a/vendors.d/kernelcare_map.json.el9
+++ b/vendors.d/kernelcare_map.json.el9
@@ -21,7 +21,7 @@
             "entries": [
                 {
                     "repoid": "kernelcare",
-                    "major_version": "7",
+                    "major_version": "8",
                     "repo_type": "rpm",
                     "arch": "x86_64",
                     "channel": "ga"


### PR DESCRIPTION
kernelcare repositories mapping for CloudLinux 8 had major_version set to CloudLinux 7 instead of CloudLinux  8