### PR TITLE
CLOS-4056: leapp-data support for no-auth CloudLinux repository scheme

### DIFF
--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el8
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el8
@@ -49,18 +49,16 @@ gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
 
 # CL repositories used during migration.
-# Enabled so CloudLinux-specific packages (cagefs, alt-php*, lve-utils, etc.)
-# are available when the target CL8 system uses the no-auth (SWNG) scheme
-# and CLN is no longer serving them. Mirrors the el9 setup.
+# Enabled so CloudLinux-specific packages are available when the source system
+# is on the no-auth scheme and CLN is no longer serving them.
 
 # cloudlinux8-channel is the primary CL8 no-auth repo (SWNG mirrorlist) we
 # provide for the upgrade transaction. It carries the full CL8 package set.
 #
 # Note: we use the distinct repoid "cloudlinux8-channel" (not "cl-channel")
 # so it does not clash with a runtime "cl-channel" repo if the source system
-# (or a mixed-state CL7 host) already defines one in /etc/yum.repos.d/. The
-# corresponding pesid in repomap.json.el8 maps cloudlinux8-channel -> this
-# repoid for CL7 sources.
+# (or a mixed-state CL7 host) already defines one in /etc/yum.repos.d/.
+# The corresponding pesid in repomap.json.el8 maps cloudlinux8-channel -> this repoid for CL7 sources.
 [cloudlinux8-channel]
 name=CloudLinux 8 - SWNG mirrorlist
 mirrorlist=https://repo.cloudlinux.com/cloudlinux/mirrorlists/cl-mirrors/cloudlinux-x86_64-server-8

--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el8
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el8
@@ -49,19 +49,46 @@ gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
 
 # CL repositories used during migration.
+# Enabled so CloudLinux-specific packages (cagefs, alt-php*, lve-utils, etc.)
+# are available when the target CL8 system uses the no-auth (SWNG) scheme
+# and CLN is no longer serving them. Mirrors the el9 setup.
 
+# cl-channel is the primary CL8 no-auth repo (SWNG mirrorlist). It serves the
+# full CL package set and is the same repoid a runtime CL8 system uses.
+[cl-channel]
+name=CloudLinux 8 - SWNG mirrorlist
+mirrorlist=https://repo.cloudlinux.com/cloudlinux/mirrorlists/cl-mirrors/cloudlinux-x86_64-server-8
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+
+# Narrower BaseOS/AppStream/PowerTools static repos (CDN-served). Smaller
+# slices of the package set; cl-channel above is the authoritative source.
+# Kept as backups when the mirrorlist is unreachable.
 [cloudlinux8-baseos]
 name=CloudLinux 8 - BaseOS
 baseurl=https://repo.cloudlinux.com/cloudlinux/8/BaseOS/$basearch/os/
-# keep cloudlinux8-baseos here because we need repository to install rhn-client-tools
-# but at the same time we don't want to use it during migration because we have CLN channel
-enabled=0
+enabled=1
 gpgcheck=1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+
+[cloudlinux8-appstream]
+name=CloudLinux 8 - AppStream
+baseurl=https://repo.cloudlinux.com/cloudlinux/8/AppStream/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+
+[cloudlinux8-powertools]
+name=CloudLinux 8 - PowerTools
+baseurl=https://repo.cloudlinux.com/cloudlinux/8/PowerTools/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
 
 [cloudlinux8-elevate]
 name=CloudLinux 8 ELevate
 baseurl=https://repo.cloudlinux.com/elevate/8/$basearch/
-gpgcheck=1
 enabled=1
+gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux

--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el8
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el8
@@ -53,9 +53,15 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
 # are available when the target CL8 system uses the no-auth (SWNG) scheme
 # and CLN is no longer serving them. Mirrors the el9 setup.
 
-# cl-channel is the primary CL8 no-auth repo (SWNG mirrorlist). It serves the
-# full CL package set and is the same repoid a runtime CL8 system uses.
-[cl-channel]
+# cloudlinux8-channel is the primary CL8 no-auth repo (SWNG mirrorlist) we
+# provide for the upgrade transaction. It carries the full CL8 package set.
+#
+# Note: we use the distinct repoid "cloudlinux8-channel" (not "cl-channel")
+# so it does not clash with a runtime "cl-channel" repo if the source system
+# (or a mixed-state CL7 host) already defines one in /etc/yum.repos.d/. The
+# corresponding pesid in repomap.json.el8 maps cloudlinux8-channel -> this
+# repoid for CL7 sources.
+[cloudlinux8-channel]
 name=CloudLinux 8 - SWNG mirrorlist
 mirrorlist=https://repo.cloudlinux.com/cloudlinux/mirrorlists/cl-mirrors/cloudlinux-x86_64-server-8
 enabled=1

--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el9
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el9
@@ -81,20 +81,32 @@ gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 # CL repositories used during migration.
+# Enabled so CloudLinux-specific packages (cagefs, alt-php*, lve-utils, etc.)
+# are available when the source system is on the no-auth (SWNG) scheme and
+# CLN is no longer serving them.
 
+# cl-channel is the primary CL9 no-auth repo (SWNG mirrorlist). It serves the
+# full CL package set and is the same repoid a runtime CL9 system uses.
+[cl-channel]
+name=CloudLinux 9 - SWNG mirrorlist
+mirrorlist=https://repo.cloudlinux.com/cloudlinux/mirrorlists/cl-mirrors/cloudlinux-x86_64-server-9
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+
+# Narrower BaseOS/AppStream static repos (CDN-served, no mirrorlist). These are
+# smaller slices of the package set; cl-channel above is the authoritative
+# source. Kept as backups for cases where the mirrorlist is unreachable.
 [cloudlinux9-baseos]
 name=CloudLinux 9 - BaseOS
 baseurl=https://repo.cloudlinux.com/cloudlinux/9/BaseOS/$basearch/os/
-# keep cloudlinux9-baseos here because we need repository to install rhn-client-tools
-# but at the same time we don't want to use it during migration because we have CLN channel
-enabled=0
+enabled=1
 gpgcheck=1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
 
-# todo: is it needed at all?
-# [cloudlinux9-elevate]
-# name=CloudLinux 9 ELevate
-# baseurl=https://repo.cloudlinux.com/elevate/9/$basearch/
-# gpgcheck=1
-# enabled=1
-# gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+[cloudlinux9-appstream]
+name=CloudLinux 9 - AppStream
+baseurl=https://repo.cloudlinux.com/cloudlinux/9/AppStream/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux

--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el9
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el9
@@ -85,9 +85,15 @@ gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-K
 # are available when the source system is on the no-auth (SWNG) scheme and
 # CLN is no longer serving them.
 
-# cl-channel is the primary CL9 no-auth repo (SWNG mirrorlist). It serves the
-# full CL package set and is the same repoid a runtime CL9 system uses.
-[cl-channel]
+# cloudlinux9-channel is the primary CL9 no-auth repo (SWNG mirrorlist) we
+# provide for the upgrade transaction. It carries the full CL9 package set.
+#
+# Note: we use the distinct repoid "cloudlinux9-channel" (not "cl-channel")
+# to avoid clashing with the runtime "cl-channel" repo from the source
+# system's /etc/yum.repos.d/cl.repo (CL8), which is carried into the target
+# upgrade container and would otherwise trigger the
+# "YUM/DNF repository defined multiple times" inhibitor.
+[cloudlinux9-channel]
 name=CloudLinux 9 - SWNG mirrorlist
 mirrorlist=https://repo.cloudlinux.com/cloudlinux/mirrorlists/cl-mirrors/cloudlinux-x86_64-server-9
 enabled=1

--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el9
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el9
@@ -81,18 +81,16 @@ gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 # CL repositories used during migration.
-# Enabled so CloudLinux-specific packages (cagefs, alt-php*, lve-utils, etc.)
-# are available when the source system is on the no-auth (SWNG) scheme and
-# CLN is no longer serving them.
+# Enabled so CloudLinux-specific packages are available when the source system
+# is on the no-auth scheme and CLN is no longer serving them.
 
 # cloudlinux9-channel is the primary CL9 no-auth repo (SWNG mirrorlist) we
 # provide for the upgrade transaction. It carries the full CL9 package set.
 #
 # Note: we use the distinct repoid "cloudlinux9-channel" (not "cl-channel")
-# to avoid clashing with the runtime "cl-channel" repo from the source
-# system's /etc/yum.repos.d/cl.repo (CL8), which is carried into the target
-# upgrade container and would otherwise trigger the
-# "YUM/DNF repository defined multiple times" inhibitor.
+# to avoid clashing with the runtime "cl-channel" repo from the source system's /etc/yum.repos.d/cl.repo,
+# which is carried into the target upgrade container and would otherwise
+# trigger the "YUM/DNF repository defined multiple times" inhibitor.
 [cloudlinux9-channel]
 name=CloudLinux 9 - SWNG mirrorlist
 mirrorlist=https://repo.cloudlinux.com/cloudlinux/mirrorlists/cl-mirrors/cloudlinux-x86_64-server-9

--- a/files/cloudlinux/repomap.json.el8
+++ b/files/cloudlinux/repomap.json.el8
@@ -306,7 +306,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "repoid": "cl-channel",
+                    "repoid": "cloudlinux8-channel",
                     "arch": "x86_64",
                     "channel": "ga"
                 }

--- a/files/cloudlinux/repomap.json.el8
+++ b/files/cloudlinux/repomap.json.el8
@@ -13,6 +13,7 @@
                 {
                     "source": "cloudlinux-base",
                     "target": [
+                        "cloudlinux8-channel",
                         "cloudlinux8-baseos",
                         "cloudlinux8-appstream",
                         "cloudlinux8-powertools"
@@ -21,6 +22,7 @@
                 {
                     "source": "cloudlinux-updates",
                     "target": [
+                        "cloudlinux8-channel",
                         "cloudlinux8-baseos",
                         "cloudlinux8-appstream",
                         "cloudlinux8-powertools"
@@ -29,6 +31,7 @@
                 {
                     "source": "cloudlinux-hybrid-updates",
                     "target": [
+                        "cloudlinux8-channel",
                         "cloudlinux8-baseos",
                         "cloudlinux8-appstream",
                         "cloudlinux8-powertools"
@@ -56,11 +59,14 @@
                 },
                 {
                     "source": "extras",
-                    "target": ["almalinux8-extras"]
+                    "target": [
+                        "almalinux8-extras"
+                    ]
                 },
                 {
                     "source": "cloudlinux-extras",
                     "target": [
+                        "cloudlinux8-channel",
                         "cloudlinux8-baseos",
                         "cloudlinux8-appstream",
                         "cloudlinux8-powertools",
@@ -70,7 +76,8 @@
                 {
                     "source": "cloudlinux-elevate",
                     "target": [
-                        "cloudlinux8-elevate"
+                        "cloudlinux8-elevate",
+                        "cloudlinux8-channel"
                     ]
                 }
             ]
@@ -288,6 +295,18 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "cloudlinux-hybrid-updates",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux8-channel",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "repoid": "cl-channel",
                     "arch": "x86_64",
                     "channel": "ga"
                 }

--- a/files/cloudlinux/repomap.json.el9
+++ b/files/cloudlinux/repomap.json.el9
@@ -68,6 +68,40 @@
                     "target": [
                         "almalinux9-saphana"
                     ]
+                },
+                {
+                    "source": "cl-channel",
+                    "target": [
+                        "cloudlinux9-channel",
+                        "cloudlinux9-baseos",
+                        "cloudlinux9-appstream"
+                    ]
+                },
+                {
+                    "source": "cloudlinux8-baseos",
+                    "target": [
+                        "cloudlinux9-channel",
+                        "cloudlinux9-baseos"
+                    ]
+                },
+                {
+                    "source": "cloudlinux8-appstream",
+                    "target": [
+                        "cloudlinux9-channel",
+                        "cloudlinux9-appstream"
+                    ]
+                },
+                {
+                    "source": "cloudlinux8-powertools",
+                    "target": [
+                        "cloudlinux9-channel"
+                    ]
+                },
+                {
+                    "source": "cloudlinux8-elevate",
+                    "target": [
+                        "cloudlinux9-channel"
+                    ]
                 }
             ]
         }
@@ -308,6 +342,102 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "almalinux9-saphana",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cl-channel",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "repoid": "cl-channel",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux8-baseos",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux8-baseos",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux8-appstream",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux8-appstream",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux8-powertools",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux8-powertools",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux8-elevate",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux8-elevate",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux9-baseos",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux9-baseos",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux9-appstream",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux9-appstream",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux9-channel",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "cl-channel",
                     "arch": "x86_64",
                     "channel": "ga"
                 }

--- a/files/cloudlinux/repomap.json.el9
+++ b/files/cloudlinux/repomap.json.el9
@@ -437,7 +437,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "cl-channel",
+                    "repoid": "cloudlinux9-channel",
                     "arch": "x86_64",
                     "channel": "ga"
                 }


### PR DESCRIPTION
Adds the leapp-data configuration for the no-auth repo scheme that is rolling out for CL8 and CL9.

The new repo configs and maps define the new scheme for Leapp to pull packages from.

Now that CLN channel is no longer the main source, the core of the upgrade process is defined entirely in leapp-data with no custom config manipulations required on the leapp-repository side.

The leapp-repository PR https://github.com/cloudlinux/leapp-repository/pull/58 adjusts the CLN-related actors correspondingly.