### PR TITLE
CLOS-2598: Add lua-cjson -> lua51-cjson REPLACED event to PES

### DIFF
--- a/files/cloudlinux/pes-events.json
+++ b/files/cloudlinux/pes-events.json
@@ -520492,6 +520492,44 @@
                 "minor_version": 0,
                 "os_name": "CloudLinux"
             }
+        },
+        {
+            "action": 3,
+            "arches": [
+                "x86_64"
+            ],
+            "id": 12948,
+            "in_packageset": {
+                "package": [
+                    {
+                        "module_stream": null,
+                        "name": "lua-cjson",
+                        "repository": "imunify360"
+                    }
+                ],
+                "set_id": 16842
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CloudLinux"
+            },
+            "is_approved": true,
+            "out_packageset": {
+                "package": [
+                    {
+                        "module_stream": null,
+                        "name": "lua51-cjson",
+                        "repository": "cloudlinux8-imunify360"
+                    }
+                ],
+                "set_id": 16843
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "CloudLinux"
+            }
         }
     ]
 }


### PR DESCRIPTION
The lua-cjson package on CL7 (Vendor: CloudLinux, from cloudlinux-updates) ships the same /usr/lib64/lua/5.1/cjson.so and test files as lua51-cjson on CL8 (from cloudlinux8-imunify360), but with different package names. Without an explicit Replaced event, Leapp queues lua51-cjson for install without removing lua-cjson, and the DNF transaction fails the test phase:

```
file /usr/lib64/lua/5.1/cjson.so from install of lua51-cjson-2.1.0-2.el8 conflicts with file from package lua-cjson-2.1.0-2.el7
```

The Replaced (action=3) event lets the transaction builder swap the two packages in a single transaction, transferring file ownership cleanly.